### PR TITLE
Modified script to use folder name between final / and .git

### DIFF
--- a/nodestack
+++ b/nodestack
@@ -322,7 +322,7 @@ case "$1" in
 
 		REPO=$2
 		PWD=$(pwd)
-		PDIR=$(echo $REPO | sed -e 's/^.\+\///' -e 's/\.git$//')
+		PDIR=$(echo $REPO | sed -e 's:.*/::' -e 's/\.git$//')
 
 		git clone $REPO
 		cd $PDIR


### PR DESCRIPTION
Using nodestack pull on zsh / OS X lead to some issues. Pull request would succeed, but then nodestack would not be able to `cd` to the directory as the path was incorrect:

```cd: git@bitbucket.org:usertech/stripe-payments-api: No such file or directory```

I have modified the sed command to select the final \ in the URL and this seems to have corrected the behaviour